### PR TITLE
fixed warning of script-fu-register:

### DIFF
--- a/images-grid-layout.scm
+++ b/images-grid-layout.scm
@@ -420,7 +420,7 @@
 
 (script-fu-register
     "script-fu-images-grid-layout"
-    "<Image>/Tools/Images Grid Layout"
+    "Images Grid Layout"
     "Script merges multiple images to another one with grid layout"
     "Kamil Svoboda"
     "2005, Kamil Svoboda"
@@ -447,3 +447,4 @@
     SF-COLOR "_Background (around images)"	'(255 255 255)
     ;SF-DIRNAME "Process all images from directory"   "Select directory"    
 )
+(script-fu-menu-register "script-fu-images-grid-layout" "<Image>/Tools")


### PR DESCRIPTION
Plug-in "script-fu"
(/usr/lib/gimp/2.0/plug-ins/script-fu/script-fu) is installing procedure "script-fu-images-grid-layout" with a full menu path "<Image>/Tools/Images Grid Layout" as menu label, this deprecated and will be an error in GIMP 3.0

based on https://docs.gimp.org/en/gimp-using-script-fu-tutorial-first-script.html